### PR TITLE
Add handling of "-" as msid-id value

### DIFF
--- a/rtcweb-msid.xml
+++ b/rtcweb-msid.xml
@@ -10,7 +10,7 @@
 <?rfc inline="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
-<rfc category="std" docName="draft-ietf-mmusic-msid-15" ipr="trust200902">
+<rfc category="std" docName="draft-ietf-mmusic-msid-16" ipr="trust200902">
   <front>
     <title abbrev="MSID in SDP">WebRTC MediaStream Identification in the
     Session Description Protocol</title>
@@ -35,7 +35,7 @@
       </address>
     </author>
 
-    <date day="7" month="July" year="2016"/>
+    <date day="23" month="January" year="2017"/>
 
     <abstract>
       <t>This document specifies a Session Description Protocol (SDP) Grouping
@@ -241,7 +241,7 @@
 
       <t>The value of the "msid-id" field in the msid consists of the "id"
       attribute of a MediaStream, as defined in the MediaStream's WebIDL
-      specification.</t>
+      specification. The special value "-" indicates "no MediaStream".</t>
 
       <t>The value of the "msid-appdata" field in the msid consists of the
       "id" attribute of a MediaStreamTrack, as defined in the
@@ -263,27 +263,32 @@
 
       <t><list style="symbols">
           <t>When a new msid "identifier" value occurs in a session
-          description, the recipient can signal to its application that a new
-          MediaStream has been added.</t>
+          description, and it is not "-", the recipient can signal to
+          its application that a new MediaStream has been added.</t>
 
           <t>When a session description is updated to have media descriptions
           with an msid "identifier" value, with one or more different
-          "appdata" values, the recipient can siggnal to its application that
-          new MediaStreamTracks have been added to the MediaStream. This is
-          done for each different msid "identifier" value.</t>
+          "appdata" values, the recipient can signal to its application that
+          new MediaStreamTracks have been added, and which MediaStream it has
+          been added to. This is
+          done for each different msid "identifier" value, including the
+          special value "-", which indicates that a MediaStreamTrack has been
+          added with no corresponding MediaStream.</t>
 
           <t>When a session description is updated to no longer list any msid
           attribute on a specific media description, the recipient can signal
           to its application that the corresponding MediaStreamTrack has
           ended.</t>
-        </list>In addition to signaling that the track is closed when its msid
+        </list>
+      </t>
+      <t>In addition to signaling that the track is ended when its msid
       attribute disappears from the SDP, the track will also be signaled as
-      being closed when all associated SSRCs have disappeared by the rules of
+      being ended when all associated SSRCs have disappeared by the rules of
       <xref target="RFC3550"/> section 6.3.4 (BYE packet received) and 6.3.5
       (timeout), or when the corresponding media description is disabled by
       setting the port number to zero. Changing the direction of the media
       description (by setting "sendonly", "recvonly" or "inactive" attributes)
-      will not close the MediaStreamTrack.</t>
+      will not end the MediaStreamTrack.</t>
 
       <t>The association between SSRCs and media descriptions is specified in
       <xref target="I-D.ietf-rtcweb-jsep"/>.</t>
@@ -777,6 +782,11 @@ a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
 
         <t>Various small changes based on review feedback during IESG
         processing.</t>
+      </section>
+      <section title="Changes from -15 to -16">
+        <t>Added the special "-" value that means "no MediaStream".</t>
+        <t>Changed instances of a MediaStreamTrack being "closed" to
+        saying it's "ended", in accordance with WebRTC terminology.</t>
       </section>
     </section>
   </back>


### PR DESCRIPTION
This reserved value means "no MediaStream".
Also fix some unrelated nits.

Closes #15